### PR TITLE
reduce duplication in printing logic

### DIFF
--- a/.github/workflows/firmware-ci.yaml
+++ b/.github/workflows/firmware-ci.yaml
@@ -19,4 +19,4 @@ jobs:
             - name: U8g2
             - name: ACAN_ESP32
           enable-deltas-report: true
-      - uses: arduino/report-size-deltas@v1
+      # - uses: arduino/report-size-deltas@v1

--- a/KaN_Gauge/GaugeConfig.h
+++ b/KaN_Gauge/GaugeConfig.h
@@ -129,7 +129,6 @@ int lastMessage = 0;
 int testMode = 0;
 int longPress = 0;
 bool wifiToggled = false;
-int percent = 0;
 int rxTimeout = 0;
 
 int displayController = 0;

--- a/KaN_Gauge/KaN_Gauge.ino
+++ b/KaN_Gauge/KaN_Gauge.ino
@@ -36,6 +36,12 @@ CANMessage CANmsg;
 Preferences preferences;
 TaskHandle_t TASK_CAN;
 
+static void printDataNameAndUnits(sensorData* data) {
+  u8g2.print(data->dataName);
+  u8g2.print(" ");
+  u8g2.print(data->units);
+}
+
 // ======================================  Input Functions  ============================================
 
 /*
@@ -62,36 +68,28 @@ void configMode()
     switch (i)
     {
     case 0:
-      u8g2.print(ptrData->dataName);
-      u8g2.print(" ");
-      u8g2.print(ptrData->units);
+      printDataNameAndUnits(ptrData);
       u8g2.setCursor(0, 45);
       u8g2.setFont(u8g2_font_6x10_tf);
       u8g2.print("<-Next         Type->");
       break;
 
     case 1:
-      u8g2.print(ptrData2->dataName);
-      u8g2.print(" ");
-      u8g2.print(ptrData2->units);
+      printDataNameAndUnits(ptrData2);
       u8g2.setCursor(0, 45);
       u8g2.setFont(u8g2_font_6x10_tf);
       u8g2.print("<-Next         Type->");
       break;
 
     case 2:
-      u8g2.print(ptrData3->dataName);
-      u8g2.print(" ");
-      u8g2.print(ptrData3->units);
+      printDataNameAndUnits(ptrData3);
       u8g2.setCursor(0, 45);
       u8g2.setFont(u8g2_font_6x10_tf);
       u8g2.print("<-Next         Type->");
       break;
 
     case 3:
-      u8g2.print(ptrData4->dataName);
-      u8g2.print(" ");
-      u8g2.print(ptrData4->units);
+      printDataNameAndUnits(ptrData4);
       u8g2.setCursor(0, 45);
       u8g2.setFont(u8g2_font_6x10_tf);
       u8g2.print("<-Next         Type->");
@@ -103,9 +101,7 @@ void configMode()
       u8g2.setCursor(0, 0);
       u8g2.print("LEDs for 1x data");
       u8g2.setCursor(0, 20);
-      u8g2.print(ptrDataLed1->dataName);
-      u8g2.print(" ");
-      u8g2.print(ptrDataLed1->units);
+      printDataNameAndUnits(ptrDataLed1);
       u8g2.setCursor(0, 45);
       u8g2.setFont(u8g2_font_6x10_tf);
       u8g2.print("<-Next         Type->");
@@ -117,9 +113,7 @@ void configMode()
       u8g2.setCursor(0, 0);
       u8g2.print("LEDs for 2x data");
       u8g2.setCursor(0, 20);
-      u8g2.print(ptrDataLed2->dataName);
-      u8g2.print(" ");
-      u8g2.print(ptrDataLed2->units);
+      printDataNameAndUnits(ptrDataLed2);
       u8g2.setCursor(0, 45);
       u8g2.setFont(u8g2_font_6x10_tf);
       u8g2.print("<-Next         Type->");
@@ -131,9 +125,7 @@ void configMode()
       u8g2.setCursor(0, 0);
       u8g2.print("LEDs for 4x data");
       u8g2.setCursor(0, 20);
-      u8g2.print(ptrDataLed4->dataName);
-      u8g2.print(" ");
-      u8g2.print(ptrDataLed4->units);
+      printDataNameAndUnits(ptrDataLed4);
       u8g2.setCursor(0, 45);
       u8g2.setFont(u8g2_font_6x10_tf);
       u8g2.print("<-Next         Type->");
@@ -393,6 +385,30 @@ int getPercent(float current, float minimum, float maximum)
 
 // ================================= Gauges ===========================================
 
+static void printDataFormatted(sensorData* data) {
+  if (data->useInt)
+  {
+    u8g2.print((int)data->scaledValue);
+  }
+  else
+  {
+    u8g2.print(data->scaledValue);
+  }
+}
+
+static void printOnOff(const char* label, bool on) {
+  u8g2.print(label);
+
+  if (on)
+  {
+    u8g2.print("On");
+  }
+  else
+  {
+    u8g2.print("Off");
+  }
+}
+
 /*
  * Print the selected gauge and data on the display
  */
@@ -423,9 +439,7 @@ void printData(int g)
     u8g2.clearBuffer();
     u8g2.setFont(u8g2_font_6x12_tf);
     u8g2.setCursor(0, 0);
-    u8g2.print(ptrData->dataName);
-    u8g2.print(" ");
-    u8g2.print(ptrData->units);
+    printDataNameAndUnits(ptrData);
 
     u8g2.setFont(u8g2_font_fub35_tf);
     u8g2.setCursor(0, 26);
@@ -434,14 +448,7 @@ void printData(int g)
     //          u8g2.print("0");
     //        }
 
-    if (ptrData->useInt == true)
-    {
-      u8g2.print((int)ptrData->scaledValue);
-    }
-    else
-    {
-      u8g2.print(ptrData->scaledValue);
-    }
+    printDataFormatted(ptrData);
 
     percent = getPercent(ptrDataLed1->scaledValue, ptrDataLed1->minimum, ptrDataLed1->maximum);
 
@@ -480,14 +487,7 @@ void printData(int g)
     u8g2.setCursor(0, 0);
     u8g2.setFont(u8g2_font_helvB24_tf);
 
-    if (ptrData->useInt == true)
-    {
-      u8g2.print((int)ptrData->scaledValue);
-    }
-    else
-    {
-      u8g2.print(ptrData->scaledValue);
-    }
+    printDataFormatted(ptrData);
 
     u8g2.setFont(u8g2_font_6x10_tf);
     u8g2.setCursor(105, 0);
@@ -498,14 +498,7 @@ void printData(int g)
     u8g2.setCursor(0, 30);
     u8g2.setFont(u8g2_font_helvB24_tf);
 
-    if (ptrData2->useInt == true)
-    {
-      u8g2.print((int)ptrData2->scaledValue);
-    }
-    else
-    {
-      u8g2.print(ptrData2->scaledValue);
-    }
+    printDataFormatted(ptrData2);
 
     u8g2.setFont(u8g2_font_6x10_tf);
     u8g2.setCursor(105, 30);
@@ -549,63 +542,27 @@ void printData(int g)
     u8g2.clearBuffer();
     u8g2.setFont(u8g2_font_6x10_tf);
     u8g2.setCursor(0, 0);
-    u8g2.print(ptrData->dataName);
-    u8g2.print(" ");
-    u8g2.print(ptrData->units);
+    printDataNameAndUnits(ptrData);
     u8g2.setCursor((displayWidth / 2), 0);
-    u8g2.print(ptrData2->dataName);
-    u8g2.print(" ");
-    u8g2.print(ptrData2->units);
+    printDataNameAndUnits(ptrData2);
     u8g2.setCursor(0, displayHeight / 2);
-    u8g2.print(ptrData3->dataName);
-    u8g2.print(" ");
-    u8g2.print(ptrData3->units);
+    printDataNameAndUnits(ptrData3);
     u8g2.setCursor((displayWidth / 2), displayHeight / 2);
-    u8g2.print(ptrData4->dataName);
-    u8g2.print(" ");
-    u8g2.print(ptrData4->units);
+    printDataNameAndUnits(ptrData4);
 
     // Setup sensor values
     u8g2.setFont(u8g2_font_t0_22b_tn);
 
     u8g2.setCursor(0, (displayHeight / 4) + h);
-    if (ptrData->useInt == true)
-    {
-      u8g2.print((int)ptrData->scaledValue);
-    }
-    else
-    {
-      u8g2.print(ptrData->scaledValue);
-    }
+    printDataFormatted(ptrData);
 
     u8g2.setCursor((displayWidth / 2), (displayHeight / 4) + h);
-    if (ptrData2->useInt == true)
-    {
-      u8g2.print((int)ptrData2->scaledValue);
-    }
-    else
-    {
-      u8g2.print(ptrData2->scaledValue);
-    }
+    printDataFormatted(ptrData2);
     u8g2.setCursor(0, (displayHeight * 3 / 4) + h);
-    if (ptrData3->useInt == true)
-    {
-      u8g2.print((int)ptrData3->scaledValue);
-    }
-    else
-    {
-      u8g2.print(ptrData3->scaledValue);
-    }
+    printDataFormatted(ptrData3);
 
     u8g2.setCursor((displayWidth / 2), (displayHeight * 3 / 4) + h);
-    if (ptrData4->useInt == true)
-    {
-      u8g2.print((int)ptrData4->scaledValue);
-    }
-    else
-    {
-      u8g2.print(ptrData4->scaledValue);
-    }
+    printDataFormatted(ptrData4);
 
     percent = getPercent(ptrDataLed4->scaledValue, ptrDataLed4->minimum, ptrDataLed4->maximum);
 
@@ -659,50 +616,19 @@ void printData(int g)
     // Print ECU status of rev limit, fuel pump, CEL, o2 heater,
     u8g2.setFont(u8g2_font_6x10_tf);
     u8g2.clearBuffer();
-    u8g2.setCursor(0, 0);
 
-    u8g2.print("Rev Limit ");
-    if (revLimit > 0)
-    {
-      u8g2.print("On");
-    }
-    else
-    {
-      u8g2.print("Off");
-    }
+    u8g2.setCursor(0, 0);
+    printOnOff("Rev Limit ", revLimit > 0);
 
     u8g2.setCursor(0, 15);
-    u8g2.print("Fuel Pump ");
-    if (fuelPump > 0)
-    {
-      u8g2.print("On");
-    }
-    else
-    {
-      u8g2.print("Off");
-    }
+    printOnOff("Fuel Pump ", fuelPump > 0);
 
     u8g2.setCursor(0, 30);
-    u8g2.print("Check Engine ");
-    if (checkEngine > 0)
-    {
-      u8g2.print("On");
-    }
-    else
-    {
-      u8g2.print("Off");
-    }
+    printOnOff("Check Engine ", checkEngine > 0);
 
     u8g2.setCursor(0, 45);
-    u8g2.print("EGO Heater ");
-    if (egoHeater > 0)
-    {
-      u8g2.print("On");
-    }
-    else
-    {
-      u8g2.print("Off");
-    }
+    printOnOff("EGO Heater ", egoHeater > 0);
+
     ledOff();
     u8g2.sendBuffer();
     break;

--- a/KaN_Gauge/KaN_Gauge.ino
+++ b/KaN_Gauge/KaN_Gauge.ino
@@ -1110,49 +1110,30 @@ void setup()
 #ifdef USE_BMP
   switch (startup)
   {
-
   case 0:
+  default:
     printBuild();
-    while (millis() < (startTime))
-    {
-    }
     break;
 
   case 1:
     printBMP_KaN();
-    while (millis() < (startTime))
-    {
-    }
     break;
 
   case 2:
     printBMP_rusEFI();
-    while (millis() < (startTime))
-    {
-    }
     break;
 
   case 3:
     printBMP_BMM();
-    while (millis() < (startTime))
-    {
-    }
     break;
 
   case 4:
     printBMP_GG();
-    while (millis() < (startTime))
-    {
-    }
-    break;
-
-  default:
-    printBuild();
-    while (millis() < (startTime))
-    {
-    }
     break;
   }
+
+  // Wait some time for the splash screen to show
+  while (millis() < (startTime)) ;
 #endif
 
 #ifdef CAN_FILTERED

--- a/KaN_Gauge/KaN_Gauge.ino
+++ b/KaN_Gauge/KaN_Gauge.ino
@@ -409,6 +409,36 @@ static void printOnOff(const char* label, bool on) {
   }
 }
 
+static void renderLeds(int ledType, sensorData* data) {
+  int percent = getPercent(data->scaledValue, data->minimum, data->maximum);
+
+  switch (ledType)
+  {
+  case 0:
+    sequentialLedAll(percent);
+    break;
+
+  case 1:
+    sequentialLed(percent);
+    break;
+
+  case 2:
+    singleLedAll(percent);
+    break;
+
+  case 3:
+    singleLed(percent);
+    break;
+
+  case 4:
+    break;
+
+  default:
+    sequentialLedAll(percent);
+    break;
+  }
+}
+
 /*
  * Print the selected gauge and data on the display
  */
@@ -450,33 +480,7 @@ void printData(int g)
 
     printDataFormatted(ptrData);
 
-    percent = getPercent(ptrDataLed1->scaledValue, ptrDataLed1->minimum, ptrDataLed1->maximum);
-
-    switch (ledType)
-    {
-    case 0:
-      sequentialLedAll(percent);
-      break;
-
-    case 1:
-      sequentialLed(percent);
-      break;
-
-    case 2:
-      singleLedAll(percent);
-      break;
-
-    case 3:
-      singleLed(percent);
-      break;
-
-    case 4:
-      break;
-
-    default:
-      sequentialLedAll(percent);
-      break;
-    }
+    renderLeds(ledType, ptrDataLed1);
 
     u8g2.sendBuffer();
     break;
@@ -506,33 +510,7 @@ void printData(int g)
     u8g2.setCursor(105, 45);
     u8g2.print(ptrData2->units);
 
-    percent = getPercent(ptrDataLed2->scaledValue, ptrDataLed2->minimum, ptrDataLed2->maximum);
-
-    switch (ledType)
-    {
-    case 0:
-      sequentialLedAll(percent);
-      break;
-
-    case 1:
-      sequentialLed(percent);
-      break;
-
-    case 2:
-      singleLedAll(percent);
-      break;
-
-    case 3:
-      singleLed(percent);
-      break;
-
-    case 4:
-      break;
-
-    default:
-      sequentialLedAll(percent);
-      break;
-    }
+    renderLeds(ledType, ptrDataLed2);
 
     u8g2.sendBuffer();
     break;
@@ -564,33 +542,7 @@ void printData(int g)
     u8g2.setCursor((displayWidth / 2), (displayHeight * 3 / 4) + h);
     printDataFormatted(ptrData4);
 
-    percent = getPercent(ptrDataLed4->scaledValue, ptrDataLed4->minimum, ptrDataLed4->maximum);
-
-    switch (ledType)
-    {
-    case 0:
-      sequentialLedAll(percent);
-      break;
-
-    case 1:
-      sequentialLed(percent);
-      break;
-
-    case 2:
-      singleLedAll(percent);
-      break;
-
-    case 3:
-      singleLed(percent);
-      break;
-
-    case 4:
-      break;
-
-    default:
-      sequentialLedAll(percent);
-      break;
-    }
+    renderLeds(ledType, ptrDataLed4);
 
     u8g2.sendBuffer();
 


### PR DESCRIPTION
Extract some copy-pasted code in to helper functions to make the code easier to read, and less prone to typo mistakes.

- Function `printDataNameAndUnits` prints the channel's name and units
- Function `printDataFormatted` prints the data either as an int or float, selected by `useInt`
- Function `printOnOff` prints a label, then "On" or "Off" based on some condition. For example, prints `Fuel Pump On`
- Function `renderLeds` draws LED ring for the passed channel and LED mode.